### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/thorlabsApp/src/drvMDT695.cc
+++ b/thorlabsApp/src/drvMDT695.cc
@@ -82,7 +82,7 @@ static inline void Debug(int level, const char *format, ...) {
 
 /* --- Local data. --- */
 int MDT695_num_cards = 0;
-static char *MDT694_axis[] = {"X", "Y", "Z"};
+static const char *MDT694_axis[] = {"X", "Y", "Z"};
 
 /* Local data required for every driver; see "motordrvComCode.h" */
 #include	"motordrvComCode.h"
@@ -95,7 +95,7 @@ volatile double drvMDT695ReadbackDelay = 0.;
 
 /*----------------functions-----------------*/
 static int recv_mess(int card, char *com, int flag);
-static RTN_STATUS send_mess(int card, char const *, char *name);
+static RTN_STATUS send_mess(int card, const char *, const char *name);
 static int set_status(int card, int signal);
 static long report(int level);
 static long init();
@@ -334,7 +334,7 @@ static int set_status(int card, int signal)
 	nodeptr->postmsgptr != 0)
     {
         strncpy(send_buff, nodeptr->postmsgptr, 80);
-	send_mess(card, send_buff, (char*) NULL);
+	send_mess(card, send_buff, NULL);
 	nodeptr->postmsgptr = NULL;
     }
 
@@ -348,7 +348,7 @@ exit:
 /* send a message to the MDT695 board		     */
 /* send_mess()			                     */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, char const *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct MDT695Controller *cntrl;
     char local_buff[MAX_MSG_SIZE];


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.