### PR TITLE
Kinesis Support

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -39,5 +39,6 @@ CHECK_RELEASE = YES
 # settings without having to modify the configure/CONFIG_SITE
 # file itself.
 -include $(TOP)/../CONFIG_SITE.local
+-include $(TOP)/../configure/CONFIG_SITE.local
 -include $(TOP)/configure/CONFIG_SITE.local
-
+-include $(TOP)/configure/CONFIG_SITE.local.$(OS_CLASS)

--- a/configure/CONFIG_SITE.local
+++ b/configure/CONFIG_SITE.local
@@ -1,0 +1,9 @@
+# Controls whether to build in the ThorLabs Kinesis support.
+
+WITH_KINESIS = NO
+
+# If building in Kinesis support, change this to the location of the Kinesis DLLs
+# This is usually in C:/Program Files/Thorlabs/Kinesis, but we need to use the
+# short path because spaces cause issues with EPICS builds.
+
+THORLABS_DIR = C:/Progra~1/Thorlabs/Kinesis

--- a/thorlabsApp/src/Makefile
+++ b/thorlabsApp/src/Makefile
@@ -15,6 +15,25 @@ LIBRARY_IOC = ThorLabs
 SRCS += ThorLabsRegister.cc
 SRCS += devMDT695.cc drvMDT695.cc
 
+ifeq ($(WITH_KINESIS),YES)
+    SRC_DIRS += $(TOP)/thorlabsApp/src/kinesis
+    
+    USR_INCLUDES = -I$(THORLABS_DIR)
+    
+    DBD += devThorLabsKinesis.dbd
+    
+    SRCS += drvKinesis.cpp
+    SRCS += drvKinesisStepper.cpp
+    SRCS += drvKinesisDC.cpp
+    
+    Thorlabs.MotionControl.KCube.DCServo_DIR += $(THORLABS_DIR)
+    ThorLabs_DLL_LIBS += Thorlabs.MotionControl.KCube.DCServo
+
+    Thorlabs.MotionControl.KCube.StepperMotor_DIR += $(THORLABS_DIR)
+    ThorLabs_DLL_LIBS += Thorlabs.MotionControl.KCube.StepperMotor
+endif
+
+
 ThorLabs_LIBS += motor asyn
 ThorLabs_LIBS += $(EPICS_BASE_IOC_LIBS)
 

--- a/thorlabsApp/src/kinesis/devThorLabsKinesis.dbd
+++ b/thorlabsApp/src/kinesis/devThorLabsKinesis.dbd
@@ -1,0 +1,1 @@
+registrar(KinesisRegister)

--- a/thorlabsApp/src/kinesis/drvKinesis.cpp
+++ b/thorlabsApp/src/kinesis/drvKinesis.cpp
@@ -1,0 +1,142 @@
+#include <stdlib.h>
+#include <conio.h>
+#include <iocsh.h>
+#include <epicsExport.h>
+
+#include "drvKinesis.h"
+
+KinesisController::KinesisController(const char* asyn_port, int serial, int type, double movingPollPeriod, double idlePollPeriod)
+	: asynMotorController(asyn_port,
+	                      1,
+	                      0,
+	                      0,
+	                      0,
+	                      ASYN_CANBLOCK | ASYN_MULTIDEVICE,
+	                      1,
+	                      0,
+	                      0)
+{
+	if      (type == KINESIS_DC_MOTOR)    { new KinesisDCMotorAxis(this, 0, serial); }
+	else if (type == KINESIS_STEP_MOTOR)  { new KinesisStepMotorAxis(this, 0, serial); }
+	
+	startPoller(movingPollPeriod, idlePollPeriod, 2);
+}
+
+KinesisAxis* KinesisController::getAxis(asynUser* pasynUser)
+{ 
+	return static_cast<KinesisAxis*>(asynMotorController::getAxis(pasynUser));
+}
+
+KinesisAxis* KinesisController::getAxis(int axis)
+{ 
+	return static_cast<KinesisAxis*>(asynMotorController::getAxis(axis)); 
+}
+
+
+KinesisAxis::KinesisAxis(KinesisController* pc, int axisNo, int serial_no)
+	: asynMotorAxis(pc, axisNo),
+	  pC_(pc)
+{
+	sprintf_s(this->serial, "%d", serial_no);
+	
+	setDoubleParam(pC_->motorEncoderPosition_, 0.0);
+	callParamCallbacks();
+}
+
+asynStatus KinesisAxis::move(double position, int relative, double minVelocity, double maxVelocity, double acceleration)
+{	
+	if (relative)    { this->moveRelative(position); }
+	else             { this->moveToPosition(position); }
+	
+	return asynSuccess;
+}
+
+asynStatus KinesisAxis::home(double minVelocity, double maxVelocity, double acceleration, int forwards)
+{
+	if (this->canHome())    { this->home();	}
+	
+	return asynSuccess;
+}
+
+asynStatus KinesisAxis::poll(bool* moving)
+{
+	int pos = this->getPosition();
+	int status = this->getStatus();
+		
+	setDoubleParam(this->pC_->motorPosition_, (double)pos);
+	
+	if ((status & 0x00000010) | (status & 0x00000020))
+	{
+		setIntegerParam(this->pC_->motorStatusMoving_, 1);
+		setIntegerParam(this->pC_->motorStatusDirection_, (status & 0x00000010) ? 0 : 1);
+		setIntegerParam(this->pC_->motorStatusDone_, 0);
+		*moving = true;
+	}
+	else
+	{
+		setIntegerParam(this->pC_->motorStatusMoving_, 0);
+		setIntegerParam(this->pC_->motorStatusDone_, 1);
+		*moving = false;
+	}
+	
+	setIntegerParam(this->pC_->motorStatusLowLimit_, (status & 0x00000001) ? 1 : 0);
+	setIntegerParam(this->pC_->motorStatusHighLimit_,  (status & 0x00000002) ? 1 : 0);
+	setIntegerParam(this->pC_->motorStatusHome_,  (status & 0x00000200) ? 1 : 0);
+	setIntegerParam(this->pC_->motorStatusHomed_, (status & 0x00000400) ? 1 : 0);
+	
+	callParamCallbacks();
+	
+	return asynSuccess;
+}
+
+asynStatus KinesisAxis::stop(double acceleration)
+{
+	this->stopImmediate();
+	
+	return asynSuccess;
+}
+
+
+extern "C" void KinesisControllerConfig(const char* asyn_port, int serial, const char* type, double movingPollPeriod, double idlePollPeriod)
+{
+	std::string motor_type(type);
+	
+	if (motor_type == "dc" || motor_type == "DC")
+	{ 
+		new KinesisController(asyn_port, serial, KINESIS_DC_MOTOR, movingPollPeriod, idlePollPeriod);
+	}
+	else if (motor_type == "stepper" || motor_type == "Stepper" ||
+	         motor_type == "step" || motor_type == "Step")
+	{
+		new KinesisController(asyn_port, serial, KINESIS_STEP_MOTOR, movingPollPeriod, idlePollPeriod);
+	}
+	else
+	{
+		printf("Unknown motor type: %s\n", type);
+	}
+}
+
+static const iocshArg KinesisControllerArg0 = {"Motor Port Name", iocshArgString};
+static const iocshArg KinesisControllerArg1 = {"Serial Number", iocshArgInt};
+static const iocshArg KinesisControllerArg2 = {"Motor Type", iocshArgString};
+static const iocshArg KinesisControllerArg3 = {"movingPollPeriod", iocshArgDouble};
+static const iocshArg KinesisControllerArg4 = {"idlePollPeriod", iocshArgDouble};
+
+static const iocshArg* const KinesisControllerArgs[] = {&KinesisControllerArg0, &KinesisControllerArg1, &KinesisControllerArg2, &KinesisControllerArg3, &KinesisControllerArg4};
+
+static const iocshFuncDef KinesisControllerDef = {"KinesisControllerConfig", 5, KinesisControllerArgs};
+
+static void KinesisControllerCallFunc(const iocshArgBuf* args)
+{
+	KinesisControllerConfig(args[0].sval, args[1].ival, args[2].sval, args[3].dval, args[4].dval);
+}
+
+static void KinesisRegister(void)
+{
+	iocshRegister(&KinesisControllerDef, KinesisControllerCallFunc);
+}
+
+extern "C"
+{
+	epicsExportRegistrar(KinesisRegister);
+}

--- a/thorlabsApp/src/kinesis/drvKinesis.h
+++ b/thorlabsApp/src/kinesis/drvKinesis.h
@@ -1,0 +1,118 @@
+#ifndef INC_DRVKINESIS_H
+#define INC_DRVKINESIS_H
+
+#include "asynMotorController.h"
+#include "asynMotorAxis.h"
+
+enum
+{
+	KINESIS_DC_MOTOR,
+	KINESIS_STEP_MOTOR,
+};
+
+class epicsShareClass KinesisController;
+
+class epicsShareClass KinesisAxis : public asynMotorAxis
+{
+	public:
+		KinesisAxis(KinesisController* controller, int axisNo, int serialNo);
+		
+		asynStatus move(double position, int relative, double min_velocity, double max_velocity, double acceleration);
+		asynStatus home(double min_velocity, double max_velocity, double acceleration, int forwards);
+		asynStatus stop(double acceleration);
+		asynStatus poll(bool* moving);
+		
+		virtual void connect() = 0;
+		virtual void disconnect() = 0;
+		
+		virtual void startPoll(int interval) = 0;
+		virtual void stopPoll() = 0;
+		
+		virtual void enableChannel() = 0;
+		virtual void disableChannel() = 0;
+		
+		virtual int getPosition() = 0;
+		virtual int getStatus() = 0;
+		
+		virtual void moveRelative(double position) = 0;
+		virtual void moveToPosition(double position) = 0;
+		
+		virtual bool canHome() = 0;
+		virtual void home() = 0;
+		
+		virtual int stopImmediate() = 0;
+		
+	protected:
+		KinesisController* pC_;
+		
+		int axisIndex_;
+		
+		char serial[16];
+};
+
+class epicsShareClass KinesisDCMotorAxis : public KinesisAxis
+{
+	public:
+		KinesisDCMotorAxis(KinesisController* controller, int axisNo, int serialNo);
+		~KinesisDCMotorAxis();
+		
+		void connect();
+		void disconnect();
+		
+		void startPoll(int interval);
+		void stopPoll();
+		
+		void enableChannel();
+		void disableChannel();
+		
+		int getPosition();
+		int getStatus();
+		
+		void moveRelative(double position);
+		void moveToPosition(double position);
+		
+		bool canHome();
+		void home();
+		
+		int stopImmediate();
+};
+
+class epicsShareClass KinesisStepMotorAxis : public KinesisAxis
+{
+	public:
+		KinesisStepMotorAxis(KinesisController* controller, int axisNo, int serialNo);
+		~KinesisStepMotorAxis();
+		
+		void connect();
+		void disconnect();
+		
+		void startPoll(int interval);
+		void stopPoll();
+		
+		void enableChannel();
+		void disableChannel();
+		
+		int getPosition();
+		int getStatus();
+		
+		void moveRelative(double position);
+		void moveToPosition(double position);
+		
+		bool canHome();
+		void home();
+		
+		int stopImmediate();
+};
+
+class epicsShareClass KinesisController : public asynMotorController
+{
+	public:
+		KinesisController(const char* portName, int serialNo, int type, double movingPollPeriod, double idlePollPeriod);
+		KinesisAxis* getAxis(asynUser* pasynuser);
+		KinesisAxis* getAxis(int axis);
+		
+	friend class KinesisAxis;
+};
+
+
+#endif

--- a/thorlabsApp/src/kinesis/drvKinesisDC.cpp
+++ b/thorlabsApp/src/kinesis/drvKinesisDC.cpp
@@ -1,0 +1,57 @@
+#include <stdlib.h>
+
+#define epicsExportSharedSymbols
+
+#include "drvKinesis.h"
+#include "Thorlabs.MotionControl.KCube.DCServo.h"
+
+/*
+ * DC Motor Implementation
+ */
+KinesisDCMotorAxis::KinesisDCMotorAxis(KinesisController* control, int axisNo, int serialNo)
+:KinesisAxis(control, axisNo, serialNo)
+{
+    this->connect();
+}
+
+KinesisDCMotorAxis::~KinesisDCMotorAxis()
+{
+    this->disableChannel();
+    this->stopPoll();
+    this->disconnect();
+}
+
+void KinesisDCMotorAxis::connect()        
+{
+    TLI_BuildDeviceList();
+    int success = CC_Open(this->serial); 
+    
+    if (success == 0)
+    {
+        // start the device polling at 200ms intervals
+        this->startPoll(200);
+        this->enableChannel();
+    }
+    else
+    {
+        printf("Error Connecting: %d\n", success);
+    }
+}
+void KinesisDCMotorAxis::disconnect()    { CC_Close(this->serial); }
+
+void KinesisDCMotorAxis::startPoll(int interval)    { CC_StartPolling(this->serial, interval); }
+void KinesisDCMotorAxis::stopPoll()                 { CC_StopPolling(this->serial); }
+
+void KinesisDCMotorAxis::enableChannel()    { CC_EnableChannel(this->serial); }
+void KinesisDCMotorAxis::disableChannel()   { CC_DisableChannel(this->serial); }
+
+int KinesisDCMotorAxis::getPosition()    { return CC_GetPosition(this->serial); }
+int KinesisDCMotorAxis::getStatus()      { return CC_GetStatusBits(this->serial); }
+
+void KinesisDCMotorAxis::moveRelative(double position)      { CC_MoveRelative(this->serial, position); }
+void KinesisDCMotorAxis::moveToPosition(double position)    { CC_MoveToPosition(this->serial, position); }
+
+bool KinesisDCMotorAxis::canHome()    { return CC_CanHome(this->serial); }
+void KinesisDCMotorAxis::home()       { CC_Home(this->serial); }
+
+int KinesisDCMotorAxis::stopImmediate()    { return CC_StopImmediate(this->serial); }

--- a/thorlabsApp/src/kinesis/drvKinesisStepper.cpp
+++ b/thorlabsApp/src/kinesis/drvKinesisStepper.cpp
@@ -1,0 +1,58 @@
+#include <stdlib.h>
+
+#define epicsExportSharedSymbols
+
+#include "drvKinesis.h"
+#include "Thorlabs.MotionControl.KCube.StepperMotor.h"
+
+
+/*
+ * Stepper Motor Implementation
+ */
+KinesisStepMotorAxis::KinesisStepMotorAxis(KinesisController* control, int axisNo, int serialNo)
+:KinesisAxis(control, axisNo, serialNo)
+{
+    this->connect();
+}
+
+KinesisStepMotorAxis::~KinesisStepMotorAxis()
+{
+    this->disableChannel();
+    this->stopPoll();
+    this->disconnect();
+}
+
+void KinesisStepMotorAxis::connect()        
+{
+    TLI_BuildDeviceList();
+    int success = SCC_Open(this->serial); 
+    
+    if (success == 0)
+    {
+        // start the device polling at 200ms intervals
+        this->startPoll(200);
+        this->enableChannel();
+    }
+    else
+    {
+        printf("Error Connecting: %d\n", success);
+    }
+}
+void KinesisStepMotorAxis::disconnect()    { SCC_Close(this->serial); }
+
+void KinesisStepMotorAxis::startPoll(int interval)    { SCC_StartPolling(this->serial, interval); }
+void KinesisStepMotorAxis::stopPoll()                 { SCC_StopPolling(this->serial); }
+
+void KinesisStepMotorAxis::enableChannel()    { SCC_EnableChannel(this->serial); }
+void KinesisStepMotorAxis::disableChannel()   { SCC_DisableChannel(this->serial); }
+
+int KinesisStepMotorAxis::getPosition()    { return SCC_GetPosition(this->serial); }
+int KinesisStepMotorAxis::getStatus()      { return SCC_GetStatusBits(this->serial); }
+
+void KinesisStepMotorAxis::moveRelative(double position)      { SCC_MoveRelative(this->serial, position); }
+void KinesisStepMotorAxis::moveToPosition(double position)    { SCC_MoveToPosition(this->serial, position); }
+
+bool KinesisStepMotorAxis::canHome()    { return SCC_CanHome(this->serial); }
+void KinesisStepMotorAxis::home()       { SCC_Home(this->serial); }
+
+int KinesisStepMotorAxis::stopImmediate()    { return SCC_StopImmediate(this->serial); }


### PR DESCRIPTION
Set up another Kinesis IOC and used the opportunity to fix some issues with the code and include the short path suggestion from Andrew. I think everything is properly capable of being included now. The support is just for the KDC101 and KST101 right now, but support for other models can easily be expanded by copying the format of the existing files and just changing the DLL function calls.

I've changed the CONFIG_SITE file to include local files that are arch specific, so that a CONFIG_SITE.local.WIN32 can be used to include Kinesis code, if installed. The support gets built into the library if WITH_KINESIS is set and a separate DBD file gets installed. This allows linux to get the more limited support and not have issues with the windows build.